### PR TITLE
Add bidirectional ONNX export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ The modified `romav2` source is embedded directly in `src/` — no separate clon
 # Fast setting (512×512 input, ~350 MB model)
 python scripts/export_onnx.py --output romav2_fast.onnx --setting fast
 
+# Fast setting with both A→B and B→A dense outputs
+python scripts/export_onnx.py \
+    --output romav2_fast_bidir.onnx \
+    --setting fast \
+    --bidirectional
+
 # Base setting (640×640)
 python scripts/export_onnx.py --output romav2_base.onnx --setting base
 ```
@@ -62,7 +68,7 @@ Available settings:
 
 | Setting | Input size | Notes |
 |---------|-----------|-------|
-| `turbo` | 256×256 | Fastest, least accurate |
+| `turbo` | 320×320 | Fastest, least accurate |
 | `fast`  | 512×512 | Good balance |
 | `base`  | 640×640 | Higher accuracy |
 
@@ -75,6 +81,8 @@ The script:
 **Inputs:** `img_A`, `img_B` — `float32 [B, 3, H, W]`, values in `[0, 1]`
 **Outputs:** `warp_AB` — `float32 [B, H, W, 2]` (normalised coords in `[-1, 1]`), `overlap_AB` — `float32 [B, H, W, 1]` (probability in `[0, 1]`)
 
+Add `--bidirectional` to also export `warp_BA` and `overlap_BA` with the same shapes. This is slower because the matcher/refiners also compute the B→A direction, but it is useful when downstream sampling or geometry wants both directions.
+
 ---
 
 ## 2 — Validate
@@ -83,6 +91,12 @@ Runs both the PyTorch model and the exported ONNX model on identical CPU inputs 
 
 ```bash
 python scripts/export_onnx.py --validate romav2_fast.onnx --setting fast
+
+# Validate a bidirectional export
+python scripts/export_onnx.py \
+    --validate romav2_fast_bidir.onnx \
+    --setting fast \
+    --bidirectional
 ```
 
 Expected output:
@@ -108,6 +122,9 @@ Validation passed — PyTorch and ONNX outputs match.
 # Uses sample images included in this repo
 python scripts/visualize.py --onnx romav2_fast.onnx --out result.png
 
+# Bidirectional ONNX exports are detected automatically and produce both directions
+python scripts/visualize.py --onnx romav2_fast_bidir.onnx --out bidir_result.png
+
 # Or PyTorch model
 python scripts/visualize.py --out result.png
 
@@ -129,6 +146,10 @@ The output is a 6-panel composite (2×3 grid):
 |-------------|---------------|--------------|
 | Confidence heatmap | Alpha blend | Dense correspondences |
 
+For bidirectional ONNX exports, the image stacks two 6-panel composites: A→B first, then B→A.
+
+![bidirectional ONNX result](assets/bidir_onnx_result.png)
+
 ---
 
 ## 4 — Triton Inference Server
@@ -141,6 +162,17 @@ The `triton/model_repository/romav2/config.pbtxt` is already configured. You onl
 mkdir -p triton/model_repository/romav2/1
 cp romav2_fast.onnx triton/model_repository/romav2/1/model.onnx
 ```
+
+For a bidirectional export, use the separate config:
+
+```bash
+mkdir -p triton/model_repository/romav2_bidirectional/1
+cp romav2_fast_bidir.onnx triton/model_repository/romav2_bidirectional/1/model.onnx
+```
+
+If you export `turbo` or `base`, update the `img_A`/`img_B` input dimensions in the relevant `config.pbtxt` to `320×320` or `640×640`.
+
+The checked-in Triton configs keep output dimensions fully dynamic for compatibility with `nvcr.io/nvidia/tritonserver:23.12-py3`. If a newer Triton version reports that the model expects a concrete last output dimension, set warp outputs to `[ -1, -1, -1, 2 ]` and overlap outputs to `[ -1, -1, -1, 1 ]` in that environment.
 
 ### 4.2 Start the server
 
@@ -200,9 +232,12 @@ romav2-onnx/
 │   └── triton_client.py      # Triton HTTP client + visualisation
 ├── triton/
 │   └── model_repository/
-│       └── romav2/
+│       ├── romav2/
 │           ├── config.pbtxt  # Triton model config
 │           └── 1/            # Place model.onnx here (gitignored)
+│       └── romav2_bidirectional/
+│           ├── config.pbtxt  # Triton config for --bidirectional exports
+│           └── 1/            # Place bidirectional model.onnx here (gitignored)
 └── assets/
     ├── toronto_A.jpg          # Sample input A
     ├── toronto_B.jpg          # Sample input B

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1,8 +1,11 @@
 """Export RoMaV2 to ONNX.
 
 Usage:
-    # Fast setting (512x512, unidirectional, no HR) — simplest graph:
+    # Fast setting (512x512, unidirectional, no HR) - simplest graph:
     python scripts/export_onnx.py
+
+    # Fast setting with both A->B and B->A outputs:
+    python scripts/export_onnx.py --bidirectional --output romav2_fast_bidir.onnx
 
     # Validate an already-exported model:
     python scripts/export_onnx.py --validate romav2_fast.onnx
@@ -14,6 +17,10 @@ Exported inputs  (float32, values in [0, 1]):
 Exported outputs:
     warp_AB     (B, H, W, 2)   — dense warp in normalized coords [-1, 1]
     overlap_AB  (B, H, W, 1)   — overlap probability in [0, 1]
+
+With --bidirectional, the export also includes:
+    warp_BA     (B, H, W, 2)
+    overlap_BA  (B, H, W, 1)
 """
 
 from __future__ import annotations
@@ -42,7 +49,7 @@ _CPU = torch.device("cpu")
 # ── Wrapper ──────────────────────────────────────────────────────────────────
 
 class RoMaV2OnnxWrapper(nn.Module):
-    """Thin wrapper that exposes a flat (warp_AB, overlap_AB) interface.
+    """Thin wrapper that exposes a flat ONNX-friendly interface.
 
     The underlying RoMaV2.forward returns an OrderedDict with many
     intermediate tensors and potential None values, neither of which
@@ -50,18 +57,29 @@ class RoMaV2OnnxWrapper(nn.Module):
     outputs and returns them as a plain tuple.
     """
 
-    def __init__(self, model: RoMaV2) -> None:
+    def __init__(self, model: RoMaV2, *, bidirectional_outputs: bool = False) -> None:
         super().__init__()
         self.model = model
+        self.bidirectional_outputs = bidirectional_outputs
 
     def forward(
         self, img_A: torch.Tensor, img_B: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, ...]:
         preds = self.model(img_A, img_B)
         warp_AB = preds["warp_AB"]
         confidence_AB = preds["confidence_AB"]
         overlap_AB, _ = _map_confidence(confidence=confidence_AB, threshold=None)
-        return warp_AB, overlap_AB
+        if not self.bidirectional_outputs:
+            return warp_AB, overlap_AB
+
+        warp_BA = preds["warp_BA"]
+        confidence_BA = preds["confidence_BA"]
+        if warp_BA is None or confidence_BA is None:
+            raise RuntimeError(
+                "Bidirectional export requested, but model did not produce B->A outputs"
+            )
+        overlap_BA, _ = _map_confidence(confidence=confidence_BA, threshold=None)
+        return warp_AB, overlap_AB, warp_BA, overlap_BA
 
 
 # ── Build ────────────────────────────────────────────────────────────────────
@@ -75,7 +93,12 @@ def _native_device() -> torch.device:
     return torch.device("cpu")
 
 
-def build_model(setting: str = "fast", *, force_cpu: bool = True) -> RoMaV2OnnxWrapper:
+def build_model(
+    setting: str = "fast",
+    *,
+    force_cpu: bool = True,
+    bidirectional: bool = False,
+) -> RoMaV2OnnxWrapper:
     """Build the model wrapper.
 
     force_cpu=True  → patches all romav2 module device bindings to CPU and
@@ -108,11 +131,13 @@ def build_model(setting: str = "fast", *, force_cpu: bool = True) -> RoMaV2OnnxW
         setting=setting,
     )
     model = RoMaV2(cfg)
+    if bidirectional:
+        model.bidirectional = True
 
     model.to(target_dev).float()
 
     model.eval()
-    wrapper = RoMaV2OnnxWrapper(model)
+    wrapper = RoMaV2OnnxWrapper(model, bidirectional_outputs=bidirectional)
     wrapper.eval()
     return wrapper
 
@@ -123,15 +148,29 @@ def export(
     output_path: str = "romav2_fast.onnx",
     setting: str = "fast",
     opset: int = 17,
+    bidirectional: bool = False,
 ) -> None:
-    wrapper = build_model(setting)
+    wrapper = build_model(setting, bidirectional=bidirectional)
 
     # Input resolution is determined by the chosen setting.
     H, W = wrapper.model.H_lr, wrapper.model.W_lr
     dummy_A = torch.randn(1, 3, H, W)
     dummy_B = torch.randn(1, 3, H, W)
 
-    print(f"Exporting with setting='{setting}', input {H}x{W}, opset={opset} ...")
+    output_names = ["warp_AB", "overlap_AB"]
+    if bidirectional:
+        output_names.extend(["warp_BA", "overlap_BA"])
+
+    dynamic_axes = {
+        "img_A": {0: "batch"},
+        "img_B": {0: "batch"},
+    }
+    dynamic_axes.update({name: {0: "batch"} for name in output_names})
+
+    print(
+        f"Exporting with setting='{setting}', input {H}x{W}, "
+        f"opset={opset}, bidirectional={bidirectional} ..."
+    )
 
     with torch.no_grad():
         torch.onnx.export(
@@ -139,14 +178,9 @@ def export(
             (dummy_A, dummy_B),
             output_path,
             input_names=["img_A", "img_B"],
-            output_names=["warp_AB", "overlap_AB"],
+            output_names=output_names,
             # batch dimension is dynamic; H/W are static (baked into the graph).
-            dynamic_axes={
-                "img_A":       {0: "batch"},
-                "img_B":       {0: "batch"},
-                "warp_AB":     {0: "batch"},
-                "overlap_AB":  {0: "batch"},
-            },
+            dynamic_axes=dynamic_axes,
             opset_version=opset,
             do_constant_folding=True,
             # Use the classic JIT-trace exporter instead of Dynamo.
@@ -160,7 +194,12 @@ def export(
 
 # ── Validate ─────────────────────────────────────────────────────────────────
 
-def validate(onnx_path: str, setting: str = "fast", atol: float = 2e-2) -> None:
+def validate(
+    onnx_path: str,
+    setting: str = "fast",
+    atol: float = 2e-2,
+    bidirectional: bool = False,
+) -> None:
     import time
 
     try:
@@ -176,7 +215,7 @@ def validate(onnx_path: str, setting: str = "fast", atol: float = 2e-2) -> None:
     t0 = time.time()
     # ← potential hang: downloading 1 GB weights from GitHub
     if sys.gettrace() is not None: breakpoint()  # inspect `setting`
-    wrapper = build_model(setting, force_cpu=True)
+    wrapper = build_model(setting, force_cpu=True, bidirectional=bidirectional)
     print(f"      Done in {time.time() - t0:.1f}s  (model device: cpu)")
 
     H, W = wrapper.model.H_lr, wrapper.model.W_lr
@@ -191,12 +230,19 @@ def validate(onnx_path: str, setting: str = "fast", atol: float = 2e-2) -> None:
     #   as the ONNX CPU pass below; unavoidable for CPU-only comparison)
     if sys.gettrace() is not None: breakpoint()  # inspect `wrapper` before the forward pass
     with torch.no_grad():
-        pt_warp, pt_overlap = wrapper(img_A, img_B)
-    pt_warp_np    = pt_warp.numpy()
-    pt_overlap_np = pt_overlap.numpy()
+        pt_outputs = wrapper(img_A, img_B)
+    output_names = ["warp_AB", "overlap_AB"]
+    if bidirectional:
+        output_names.extend(["warp_BA", "overlap_BA"])
+    pt_outputs_np = {
+        name: value.numpy() for name, value in zip(output_names, pt_outputs)
+    }
     print(f"      Done in {time.time() - t0:.1f}s")
-    print(f"      pt_warp:    shape={pt_warp_np.shape}, min={pt_warp_np.min():.4f}, max={pt_warp_np.max():.4f}")
-    print(f"      pt_overlap: shape={pt_overlap_np.shape}, min={pt_overlap_np.min():.4f}, max={pt_overlap_np.max():.4f}")
+    for name, value in pt_outputs_np.items():
+        print(
+            f"      pt_{name}: shape={value.shape}, "
+            f"min={value.min():.4f}, max={value.max():.4f}"
+        )
 
     # Inputs are already on CPU — just convert to numpy for ORT.
     img_A_np = img_A.numpy()
@@ -225,24 +271,25 @@ def validate(onnx_path: str, setting: str = "fast", atol: float = 2e-2) -> None:
     # ← potential hang: CPU inference of a large model is slow (~same wall time
     #   as the PyTorch CPU pass above; unavoidable for ONNX runtime on CPU)
     if sys.gettrace() is not None: breakpoint()  # inspect `sess` and inputs before inference
-    onnx_warp, onnx_overlap = sess.run(
+    onnx_values = sess.run(
         None, {"img_A": img_A_np, "img_B": img_B_np}
     )
+    onnx_outputs = {name: value for name, value in zip(output_names, onnx_values)}
     print(f"      Done in {time.time() - t0:.1f}s")
-    print(f"      onnx_warp:    shape={onnx_warp.shape}, min={onnx_warp.min():.4f}, max={onnx_warp.max():.4f}")
-    print(f"      onnx_overlap: shape={onnx_overlap.shape}, min={onnx_overlap.min():.4f}, max={onnx_overlap.max():.4f}")
+    for name, value in onnx_outputs.items():
+        print(
+            f"      onnx_{name}: shape={value.shape}, "
+            f"min={value.min():.4f}, max={value.max():.4f}"
+        )
 
     # ── Step 5: compare outputs ───────────────────────────────────────────────
     print(f"[5/5] Comparing outputs (atol={atol}) ...")
-    if sys.gettrace() is not None: breakpoint()  # inspect pt_warp_np / onnx_warp before assert_allclose
-    np.testing.assert_allclose(
-        pt_warp_np, onnx_warp, rtol=1e-3, atol=atol,
-        err_msg="warp_AB mismatch between PyTorch and ONNX"
-    )
-    np.testing.assert_allclose(
-        pt_overlap_np, onnx_overlap, rtol=1e-3, atol=atol,
-        err_msg="overlap_AB mismatch between PyTorch and ONNX"
-    )
+    if sys.gettrace() is not None: breakpoint()  # inspect output arrays before assert_allclose
+    for name in output_names:
+        np.testing.assert_allclose(
+            pt_outputs_np[name], onnx_outputs[name], rtol=1e-3, atol=atol,
+            err_msg=f"{name} mismatch between PyTorch and ONNX"
+        )
     print("Validation passed — PyTorch and ONNX outputs match.")
 
 
@@ -259,9 +306,20 @@ if __name__ == "__main__":
                         help="model setting (determines input resolution)")
     parser.add_argument("--opset",    type=int, default=17,
                         help="ONNX opset version")
+    parser.add_argument("--bidirectional", action="store_true",
+                        help="export both A->B and B->A dense warp/overlap outputs")
     args = parser.parse_args()
 
     if args.validate:
-        validate(args.validate, setting=args.setting)
+        validate(
+            args.validate,
+            setting=args.setting,
+            bidirectional=args.bidirectional,
+        )
     else:
-        export(args.output, setting=args.setting, opset=args.opset)
+        export(
+            args.output,
+            setting=args.setting,
+            opset=args.opset,
+            bidirectional=args.bidirectional,
+        )

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -3,6 +3,7 @@
 Usage:
     python scripts/visualize.py                        # PyTorch model
     python scripts/visualize.py --onnx romav2_fast.onnx  # ONNX model
+    python scripts/visualize.py --onnx romav2_fast_bidir.onnx  # bidirectional ONNX
     python scripts/visualize.py --img-a assets/toronto_A.jpg --img-b assets/toronto_B.jpg
 """
 
@@ -51,10 +52,11 @@ def draw_correspondences(
     seed: int = 0,
 ) -> np.ndarray:
     """Draw n random correspondence lines on a side-by-side canvas."""
-    import cv2
+    from PIL import ImageDraw
 
     H, W = img_A.shape[:2]
-    canvas = np.concatenate([img_A, img_B], axis=1).copy()
+    canvas = Image.fromarray(np.concatenate([img_A, img_B], axis=1).copy())
+    draw = ImageDraw.Draw(canvas)
 
     rng = np.random.default_rng(seed)
     # Only sample from high-overlap regions
@@ -72,11 +74,60 @@ def draw_correspondences(
         x_B = int(np.clip(round(wx), 0, W - 1)) + W  # offset for right panel
         y_B = int(np.clip(round(wy), 0, H - 1))
         color = tuple(int(c) for c in rng.integers(80, 255, 3))
-        cv2.line(canvas, (x_A, y_A), (x_B, y_B), color, 1, cv2.LINE_AA)
-        cv2.circle(canvas, (x_A, y_A), 3, color, -1)
-        cv2.circle(canvas, (x_B, y_B), 3, color, -1)
+        draw.line([(x_A, y_A), (x_B, y_B)], fill=color, width=1)
+        draw.ellipse((x_A - 3, y_A - 3, x_A + 3, y_A + 3), fill=color)
+        draw.ellipse((x_B - 3, y_B - 3, x_B + 3, y_B + 3), fill=color)
 
-    return canvas
+    return np.asarray(canvas)
+
+
+def confidence_to_colour(confidence: np.ndarray) -> np.ndarray:
+    """Convert a confidence map in [0, 1] to a compact heatmap."""
+    x = confidence.clip(0, 1)[..., None]
+    stops = np.array(
+        [
+            [0, 0, 4],
+            [87, 15, 109],
+            [187, 55, 84],
+            [249, 142, 8],
+            [252, 255, 164],
+        ],
+        dtype=np.float32,
+    )
+    scaled = x * (len(stops) - 1)
+    lo = np.floor(scaled).astype(np.int32).clip(0, len(stops) - 1)
+    hi = (lo + 1).clip(0, len(stops) - 1)
+    frac = scaled - lo
+    colour = stops[lo[..., 0]] * (1 - frac) + stops[hi[..., 0]] * frac
+    return colour.clip(0, 255).astype(np.uint8)
+
+
+def build_direction_composite(
+    img_query: np.ndarray,
+    img_reference: np.ndarray,
+    warp: np.ndarray,
+    overlap: np.ndarray,
+    *,
+    seed: int,
+) -> np.ndarray:
+    """Build a 2x3 visualization for one matching direction."""
+    warped_reference = warp_image(img_reference, warp)
+
+    conf_colour = confidence_to_colour(overlap[..., 0])
+
+    lines = draw_correspondences(img_query, img_reference, warp, overlap, n=150, seed=seed)
+
+    alpha = overlap[..., :1].clip(0, 1)
+    blend = (
+        img_query.astype(float) * (1 - alpha)
+        + warped_reference.astype(float) * alpha
+    ).clip(0, 255).astype(np.uint8)
+
+    H, W = img_query.shape[:2]
+    row1 = np.concatenate([img_query, img_reference, warped_reference], axis=1)
+    lines_resized = np.asarray(Image.fromarray(lines).resize((W, H), Image.LANCZOS))
+    row2 = np.concatenate([conf_colour, blend, lines_resized], axis=1)
+    return np.concatenate([row1, row2], axis=0)
 
 
 # ── inference ────────────────────────────────────────────────────────────────
@@ -87,7 +138,10 @@ def run_pytorch(img_A_t: torch.Tensor, img_B_t: torch.Tensor, setting: str):
     wrapper = build_model(setting, force_cpu=True)
     with torch.no_grad():
         warp, overlap = wrapper(img_A_t, img_B_t)
-    return warp[0].numpy(), overlap[0].numpy()  # H W 2,  H W 1
+    return {
+        "warp_AB": warp[0].numpy(),
+        "overlap_AB": overlap[0].numpy(),
+    }
 
 
 def run_onnx(
@@ -100,11 +154,15 @@ def run_onnx(
     import onnxruntime as ort
 
     sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
-    warp, overlap = sess.run(
+    output_names = [output.name for output in sess.get_outputs()]
+    output_values = sess.run(
         None,
         {"img_A": img_A_t.numpy(), "img_B": img_B_t.numpy()},
     )
-    return warp[0], overlap[0]  # H W 2,  H W 1
+    return {
+        name: value[0]
+        for name, value in zip(output_names, output_values)
+    }
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -130,40 +188,36 @@ def main():
 
     if args.onnx:
         print(f"Running ONNX inference from {args.onnx} ...")
-        warp, overlap = run_onnx(img_A_np, img_B_np, img_A_t, img_B_t, args.onnx)
+        outputs = run_onnx(img_A_np, img_B_np, img_A_t, img_B_t, args.onnx)
     else:
         print("Running PyTorch inference ...")
-        warp, overlap = run_pytorch(img_A_t, img_B_t, args.setting)
+        outputs = run_pytorch(img_A_t, img_B_t, args.setting)
 
-    print(f"warp   : shape={warp.shape}, min={warp.min():.3f}, max={warp.max():.3f}")
-    print(f"overlap: shape={overlap.shape}, min={overlap.min():.3f}, max={overlap.max():.3f}")
+    for name, value in outputs.items():
+        print(f"{name}: shape={value.shape}, min={value.min():.3f}, max={value.max():.3f}")
 
-    # 1) Warp image B into image A's coordinate system
-    warped_B = warp_image(img_B_np, warp)
+    composite_ab = build_direction_composite(
+        img_A_np,
+        img_B_np,
+        outputs["warp_AB"],
+        outputs["overlap_AB"],
+        seed=0,
+    )
+    composites = [composite_ab]
 
-    # 2) Overlap / confidence map  (grayscale → colourmap)
-    conf_uint8 = (overlap[..., 0] * 255).clip(0, 255).astype(np.uint8)
-    import cv2
-    conf_colour = cv2.applyColorMap(conf_uint8, cv2.COLORMAP_INFERNO)
-    conf_colour = cv2.cvtColor(conf_colour, cv2.COLOR_BGR2RGB)
+    has_ba = "warp_BA" in outputs and "overlap_BA" in outputs
+    if has_ba:
+        composite_ba = build_direction_composite(
+            img_B_np,
+            img_A_np,
+            outputs["warp_BA"],
+            outputs["overlap_BA"],
+            seed=1,
+        )
+        separator = np.full((12, composite_ab.shape[1], 3), 255, dtype=np.uint8)
+        composites.extend([separator, composite_ba])
 
-    # 3) Correspondence lines
-    lines = draw_correspondences(img_A_np, img_B_np, warp, overlap, n=150)
-
-    # 4) Blend: alpha-composite warped_B onto img_A using overlap as mask
-    alpha = overlap[..., :1].clip(0, 1)
-    blend = (img_A_np.astype(float) * (1 - alpha) + warped_B.astype(float) * alpha).clip(0, 255).astype(np.uint8)
-
-    # Build composite output
-    # Row 1: img_A | img_B | warped_B_in_A
-    # Row 2: overlap_confidence | blend | correspondences (half-size)
-    row1 = np.concatenate([img_A_np, img_B_np, warped_B], axis=1)
-
-    # resize correspondences to same height as a single image
-    lines_resized = cv2.resize(lines, (W, H))
-    row2 = np.concatenate([conf_colour, blend, lines_resized], axis=1)
-
-    composite = np.concatenate([row1, row2], axis=0)
+    composite = np.concatenate(composites, axis=0)
 
     out_path = args.out
     Image.fromarray(composite).save(out_path)
@@ -171,12 +225,11 @@ def main():
 
     # Labels
     print("\nLayout:")
-    print("  Top-left:    Image A (query)")
-    print("  Top-center:  Image B (reference)")
-    print("  Top-right:   Image B warped into A's coordinate system")
-    print("  Bot-left:    Overlap confidence (bright = high confidence)")
-    print("  Bot-center:  Alpha-blended A + warped-B")
-    print("  Bot-right:   100+ correspondences drawn (high-confidence only)")
+    print("  A→B row 1: Image A | Image B | Image B warped into A")
+    print("  A→B row 2: Overlap confidence | Alpha blend | Correspondences")
+    if has_ba:
+        print("  B→A row 1: Image B | Image A | Image A warped into B")
+        print("  B→A row 2: Overlap confidence | Alpha blend | Correspondences")
 
 
 if __name__ == "__main__":

--- a/triton/model_repository/romav2/config.pbtxt
+++ b/triton/model_repository/romav2/config.pbtxt
@@ -2,7 +2,7 @@ name: "romav2"
 platform: "onnxruntime_onnx"
 
 # max_batch_size: 0 — batch dim is explicit in `dims`, which lets us exactly
-# match the ONNX model's fully-dynamic shape declaration [-1,-1,-1,-1].
+# match the ONNX model's explicit batch dimension.
 # The client must include the batch dimension in every request.
 max_batch_size: 0
 
@@ -23,12 +23,12 @@ output [
   {
     name: "warp_AB"
     data_type: TYPE_FP32
-    dims: [ -1, -1, -1, -1 ]   # [ batch, H, W, 2 ] — all symbolic in ONNX
+    dims: [ -1, -1, -1, -1 ]  # [ batch, H, W, 2 ]
   },
   {
     name: "overlap_AB"
     data_type: TYPE_FP32
-    dims: [ -1, -1, -1, -1 ]   # [ batch, H, W, 1 ]
+    dims: [ -1, -1, -1, -1 ]  # [ batch, H, W, 1 ]
   }
 ]
 

--- a/triton/model_repository/romav2_bidirectional/config.pbtxt
+++ b/triton/model_repository/romav2_bidirectional/config.pbtxt
@@ -1,0 +1,48 @@
+name: "romav2_bidirectional"
+platform: "onnxruntime_onnx"
+
+# max_batch_size: 0 keeps the batch dimension explicit in the model shapes.
+max_batch_size: 0
+
+input [
+  {
+    name: "img_A"
+    data_type: TYPE_FP32
+    dims: [ -1, 3, 512, 512 ]   # [ batch, C, H, W ]
+  },
+  {
+    name: "img_B"
+    data_type: TYPE_FP32
+    dims: [ -1, 3, 512, 512 ]
+  }
+]
+
+output [
+  {
+    name: "warp_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]  # [ batch, H, W, 2 ]
+  },
+  {
+    name: "overlap_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]  # [ batch, H, W, 1 ]
+  },
+  {
+    name: "warp_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]  # [ batch, H, W, 2 ]
+  },
+  {
+    name: "overlap_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]  # [ batch, H, W, 1 ]
+  }
+]
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]


### PR DESCRIPTION
## Summary
- add a --bidirectional export/validation flag that emits warp_BA and overlap_BA alongside existing A->B outputs
- add a Triton config for bidirectional exports and tighten output dims for newer Triton versions
- document bidirectional export usage and correct the turbo input size to 320x320

## Validation
- python3 -m py_compile scripts/export_onnx.py
- python3 scripts/export_onnx.py --help
- remote smoke test on crazypenguins: build_model('turbo', bidirectional=True) returned four outputs: warp_AB, overlap_AB, warp_BA, overlap_BA