### PR TITLE
Add Triton sampled bidirectional ensemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ The script:
 
 Add `--bidirectional` to also export `warp_BA` and `overlap_BA` with the same shapes. This is slower because the matcher/refiners also compute the B→A direction, but it is useful when downstream sampling or geometry wants both directions.
 
+Add `--include-precision` for models that will feed the Triton sampled ensemble. This also exports `precision_AB` and, with `--bidirectional`, `precision_BA`, matching the precision matrices consumed by RoMaV2's `sample()` flow:
+
+```bash
+python scripts/export_onnx.py \
+    --output romav2_fast_bidir_precision.onnx \
+    --setting fast \
+    --bidirectional \
+    --include-precision
+```
+
 ---
 
 ## 2 — Validate
@@ -170,9 +180,19 @@ mkdir -p triton/model_repository/romav2_bidirectional/1
 cp romav2_fast_bidir.onnx triton/model_repository/romav2_bidirectional/1/model.onnx
 ```
 
+To avoid returning dense `H×W×...` tensors over the network, use the sampled ensemble. It chains a precision-exported bidirectional ONNX model into `romav2_sampler`, a Triton Python backend implementation of RoMaV2's sampling flow:
+
+```bash
+mkdir -p triton/model_repository/romav2_bidirectional_dense/1
+cp romav2_fast_bidir_precision.onnx \
+  triton/model_repository/romav2_bidirectional_dense/1/model.onnx
+```
+
+Then call the user-facing ensemble model `romav2_bidirectional_sampled`, not the dense model. The dense tensors stay inside Triton.
+
 If you export `turbo` or `base`, update the `img_A`/`img_B` input dimensions in the relevant `config.pbtxt` to `320×320` or `640×640`.
 
-The checked-in Triton configs keep output dimensions fully dynamic for compatibility with `nvcr.io/nvidia/tritonserver:23.12-py3`. If a newer Triton version reports that the model expects a concrete last output dimension, set warp outputs to `[ -1, -1, -1, 2 ]` and overlap outputs to `[ -1, -1, -1, 1 ]` in that environment.
+The checked-in Triton configs keep output dimensions fully dynamic for compatibility with `nvcr.io/nvidia/tritonserver:23.12-py3`. If a newer Triton version reports that the model expects concrete output dimensions, set warp outputs to `[ -1, -1, -1, 2 ]`, overlap outputs to `[ -1, -1, -1, 1 ]`, and precision outputs to `[ -1, -1, -1, 2, 2 ]` in that environment.
 
 ### 4.2 Start the server
 
@@ -199,6 +219,25 @@ python scripts/triton_client.py \
     assets/toronto_A.jpg assets/toronto_B.jpg \
     --url localhost:8000 \
     --out result.png
+```
+
+For the sampled ensemble:
+
+```bash
+python scripts/triton_sampled_client.py \
+    assets/toronto_A.jpg assets/toronto_B.jpg \
+    --url localhost:8000 \
+    --model romav2_bidirectional_sampled \
+    --num-corresp 5000
+```
+
+The sampled ensemble returns:
+
+```text
+sampled_matches      (N, 4)       # x_A, y_A, x_B, y_B in normalized coordinates
+sampled_confidence   (N,)
+sampled_precision_A  (N, 2, 2)
+sampled_precision_B  (N, 2, 2)
 ```
 
 ### 4.4 Use the client in Python
@@ -229,15 +268,25 @@ romav2-onnx/
 ├── scripts/
 │   ├── export_onnx.py        # Export + validate
 │   ├── visualize.py          # 6-panel visualisation (ONNX or PyTorch)
-│   └── triton_client.py      # Triton HTTP client + visualisation
+│   ├── triton_client.py      # Triton HTTP client + visualisation
+│   └── triton_sampled_client.py
 ├── triton/
 │   └── model_repository/
 │       ├── romav2/
 │           ├── config.pbtxt  # Triton model config
 │           └── 1/            # Place model.onnx here (gitignored)
-│       └── romav2_bidirectional/
+│       ├── romav2_bidirectional/
 │           ├── config.pbtxt  # Triton config for --bidirectional exports
 │           └── 1/            # Place bidirectional model.onnx here (gitignored)
+│       ├── romav2_bidirectional_dense/
+│       │   ├── config.pbtxt  # Internal dense ONNX model for the sampled ensemble
+│       │   └── 1/            # Place precision-exported bidirectional model.onnx here
+│       ├── romav2_sampler/
+│       │   ├── config.pbtxt  # Triton Python backend sampler
+│       │   └── 1/
+│       └── romav2_bidirectional_sampled/
+│           ├── config.pbtxt  # User-facing ensemble returning sparse samples
+│           └── 1/            # Empty version directory required by Triton
 └── assets/
     ├── toronto_A.jpg          # Sample input A
     ├── toronto_B.jpg          # Sample input B

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -21,6 +21,10 @@ Exported outputs:
 With --bidirectional, the export also includes:
     warp_BA     (B, H, W, 2)
     overlap_BA  (B, H, W, 1)
+
+With --include-precision, the export also includes:
+    precision_AB  (B, H, W, 2, 2)
+    precision_BA  (B, H, W, 2, 2)  # when combined with --bidirectional
 """
 
 from __future__ import annotations
@@ -57,10 +61,17 @@ class RoMaV2OnnxWrapper(nn.Module):
     outputs and returns them as a plain tuple.
     """
 
-    def __init__(self, model: RoMaV2, *, bidirectional_outputs: bool = False) -> None:
+    def __init__(
+        self,
+        model: RoMaV2,
+        *,
+        bidirectional_outputs: bool = False,
+        precision_outputs: bool = False,
+    ) -> None:
         super().__init__()
         self.model = model
         self.bidirectional_outputs = bidirectional_outputs
+        self.precision_outputs = precision_outputs
 
     def forward(
         self, img_A: torch.Tensor, img_B: torch.Tensor
@@ -68,8 +79,10 @@ class RoMaV2OnnxWrapper(nn.Module):
         preds = self.model(img_A, img_B)
         warp_AB = preds["warp_AB"]
         confidence_AB = preds["confidence_AB"]
-        overlap_AB, _ = _map_confidence(confidence=confidence_AB, threshold=None)
+        overlap_AB, precision_AB = _map_confidence(confidence=confidence_AB, threshold=None)
         if not self.bidirectional_outputs:
+            if self.precision_outputs:
+                return warp_AB, overlap_AB, precision_AB
             return warp_AB, overlap_AB
 
         warp_BA = preds["warp_BA"]
@@ -78,7 +91,9 @@ class RoMaV2OnnxWrapper(nn.Module):
             raise RuntimeError(
                 "Bidirectional export requested, but model did not produce B->A outputs"
             )
-        overlap_BA, _ = _map_confidence(confidence=confidence_BA, threshold=None)
+        overlap_BA, precision_BA = _map_confidence(confidence=confidence_BA, threshold=None)
+        if self.precision_outputs:
+            return warp_AB, overlap_AB, precision_AB, warp_BA, overlap_BA, precision_BA
         return warp_AB, overlap_AB, warp_BA, overlap_BA
 
 
@@ -98,6 +113,7 @@ def build_model(
     *,
     force_cpu: bool = True,
     bidirectional: bool = False,
+    include_precision: bool = False,
 ) -> RoMaV2OnnxWrapper:
     """Build the model wrapper.
 
@@ -137,7 +153,11 @@ def build_model(
     model.to(target_dev).float()
 
     model.eval()
-    wrapper = RoMaV2OnnxWrapper(model, bidirectional_outputs=bidirectional)
+    wrapper = RoMaV2OnnxWrapper(
+        model,
+        bidirectional_outputs=bidirectional,
+        precision_outputs=include_precision,
+    )
     wrapper.eval()
     return wrapper
 
@@ -149,8 +169,13 @@ def export(
     setting: str = "fast",
     opset: int = 17,
     bidirectional: bool = False,
+    include_precision: bool = False,
 ) -> None:
-    wrapper = build_model(setting, bidirectional=bidirectional)
+    wrapper = build_model(
+        setting,
+        bidirectional=bidirectional,
+        include_precision=include_precision,
+    )
 
     # Input resolution is determined by the chosen setting.
     H, W = wrapper.model.H_lr, wrapper.model.W_lr
@@ -158,8 +183,12 @@ def export(
     dummy_B = torch.randn(1, 3, H, W)
 
     output_names = ["warp_AB", "overlap_AB"]
+    if include_precision:
+        output_names.append("precision_AB")
     if bidirectional:
         output_names.extend(["warp_BA", "overlap_BA"])
+        if include_precision:
+            output_names.append("precision_BA")
 
     dynamic_axes = {
         "img_A": {0: "batch"},
@@ -169,7 +198,8 @@ def export(
 
     print(
         f"Exporting with setting='{setting}', input {H}x{W}, "
-        f"opset={opset}, bidirectional={bidirectional} ..."
+        f"opset={opset}, bidirectional={bidirectional}, "
+        f"include_precision={include_precision} ..."
     )
 
     with torch.no_grad():
@@ -199,6 +229,7 @@ def validate(
     setting: str = "fast",
     atol: float = 2e-2,
     bidirectional: bool = False,
+    include_precision: bool = False,
 ) -> None:
     import time
 
@@ -215,7 +246,12 @@ def validate(
     t0 = time.time()
     # ← potential hang: downloading 1 GB weights from GitHub
     if sys.gettrace() is not None: breakpoint()  # inspect `setting`
-    wrapper = build_model(setting, force_cpu=True, bidirectional=bidirectional)
+    wrapper = build_model(
+        setting,
+        force_cpu=True,
+        bidirectional=bidirectional,
+        include_precision=include_precision,
+    )
     print(f"      Done in {time.time() - t0:.1f}s  (model device: cpu)")
 
     H, W = wrapper.model.H_lr, wrapper.model.W_lr
@@ -232,8 +268,12 @@ def validate(
     with torch.no_grad():
         pt_outputs = wrapper(img_A, img_B)
     output_names = ["warp_AB", "overlap_AB"]
+    if include_precision:
+        output_names.append("precision_AB")
     if bidirectional:
         output_names.extend(["warp_BA", "overlap_BA"])
+        if include_precision:
+            output_names.append("precision_BA")
     pt_outputs_np = {
         name: value.numpy() for name, value in zip(output_names, pt_outputs)
     }
@@ -308,6 +348,8 @@ if __name__ == "__main__":
                         help="ONNX opset version")
     parser.add_argument("--bidirectional", action="store_true",
                         help="export both A->B and B->A dense warp/overlap outputs")
+    parser.add_argument("--include-precision", action="store_true",
+                        help="also export precision matrices used by RoMaV2.sample")
     args = parser.parse_args()
 
     if args.validate:
@@ -315,6 +357,7 @@ if __name__ == "__main__":
             args.validate,
             setting=args.setting,
             bidirectional=args.bidirectional,
+            include_precision=args.include_precision,
         )
     else:
         export(
@@ -322,4 +365,5 @@ if __name__ == "__main__":
             setting=args.setting,
             opset=args.opset,
             bidirectional=args.bidirectional,
+            include_precision=args.include_precision,
         )

--- a/scripts/triton_sampled_client.py
+++ b/scripts/triton_sampled_client.py
@@ -1,0 +1,162 @@
+"""RoMaV2 Triton sampled ensemble client.
+
+Usage:
+    python scripts/triton_sampled_client.py assets/toronto_A.jpg assets/toronto_B.jpg
+    python scripts/triton_sampled_client.py assets/toronto_A.jpg assets/toronto_B.jpg --out sampled.png
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+
+MODEL_H = MODEL_W = 512
+
+
+def load_image(path: str) -> np.ndarray:
+    img = Image.open(path).convert("RGB").resize((MODEL_W, MODEL_H), Image.LANCZOS)
+    arr = np.array(img, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1)[None]
+
+
+def infer_sampled(
+    img_a: str,
+    img_b: str,
+    *,
+    url: str,
+    model_name: str,
+    num_corresp: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    try:
+        import tritonclient.http as httpclient
+    except ImportError:
+        raise SystemExit("tritonclient is required: pip install tritonclient[http]")
+
+    image_a = load_image(img_a)
+    image_b = load_image(img_b)
+    num = np.array([num_corresp], dtype=np.int64)
+    seed_arr = np.array([seed], dtype=np.int64)
+
+    inputs = [
+        httpclient.InferInput("img_A", image_a.shape, "FP32"),
+        httpclient.InferInput("img_B", image_b.shape, "FP32"),
+        httpclient.InferInput("num_corresp", num.shape, "INT64"),
+        httpclient.InferInput("seed", seed_arr.shape, "INT64"),
+    ]
+    inputs[0].set_data_from_numpy(image_a)
+    inputs[1].set_data_from_numpy(image_b)
+    inputs[2].set_data_from_numpy(num)
+    inputs[3].set_data_from_numpy(seed_arr)
+
+    outputs = [
+        httpclient.InferRequestedOutput("sampled_matches"),
+        httpclient.InferRequestedOutput("sampled_confidence"),
+        httpclient.InferRequestedOutput("sampled_precision_A"),
+        httpclient.InferRequestedOutput("sampled_precision_B"),
+    ]
+    client = httpclient.InferenceServerClient(url=url)
+    response = client.infer(model_name=model_name, inputs=inputs, outputs=outputs)
+    return (
+        response.as_numpy("sampled_matches"),
+        response.as_numpy("sampled_confidence"),
+        response.as_numpy("sampled_precision_A"),
+        response.as_numpy("sampled_precision_B"),
+    )
+
+
+def _to_pixel(points: np.ndarray, *, width: int, height: int) -> np.ndarray:
+    x = (points[:, 0] + 1.0) / 2.0 * width - 0.5
+    y = (points[:, 1] + 1.0) / 2.0 * height - 0.5
+    return np.stack((x, y), axis=-1)
+
+
+def visualise_sampled(
+    img_a_path: str,
+    img_b_path: str,
+    matches: np.ndarray,
+    confidence: np.ndarray,
+    out_path: str,
+    *,
+    max_lines: int = 512,
+) -> None:
+    img_a = Image.open(img_a_path).convert("RGB").resize((MODEL_W, MODEL_H), Image.LANCZOS)
+    img_b = Image.open(img_b_path).convert("RGB").resize((MODEL_W, MODEL_H), Image.LANCZOS)
+    canvas = Image.new("RGB", (MODEL_W * 2, MODEL_H), "white")
+    canvas.paste(img_a, (0, 0))
+    canvas.paste(img_b, (MODEL_W, 0))
+
+    count = min(max_lines, matches.shape[0])
+    order = np.argsort(confidence)[::-1][:count]
+    pts_a = _to_pixel(matches[order, :2], width=MODEL_W, height=MODEL_H)
+    pts_b = _to_pixel(matches[order, 2:], width=MODEL_W, height=MODEL_H)
+    conf = confidence[order]
+    conf_min = float(conf.min()) if conf.size else 0.0
+    conf_max = float(conf.max()) if conf.size else 1.0
+    denom = max(conf_max - conf_min, 1e-6)
+
+    overlay = Image.new("RGBA", canvas.size, (255, 255, 255, 0))
+    draw = ImageDraw.Draw(overlay)
+    for point_a, point_b, score in zip(pts_a, pts_b, conf):
+        t = float((score - conf_min) / denom)
+        color = (
+            int(40 + 215 * t),
+            int(220 - 180 * t),
+            int(255 - 220 * t),
+            165,
+        )
+        x_a, y_a = point_a
+        x_b, y_b = point_b
+        x_b += MODEL_W
+        draw.line([(x_a, y_a), (x_b, y_b)], fill=color, width=1)
+        draw.ellipse((x_a - 2, y_a - 2, x_a + 2, y_a + 2), fill=color)
+        draw.ellipse((x_b - 2, y_b - 2, x_b + 2, y_b + 2), fill=color)
+
+    visual = Image.alpha_composite(canvas.convert("RGBA"), overlay).convert("RGB")
+    visual.save(out_path)
+    print(f"Saved → {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the RoMaV2 sampled Triton ensemble")
+    parser.add_argument("img_a")
+    parser.add_argument("img_b")
+    parser.add_argument("--url", default="localhost:8000")
+    parser.add_argument("--model", default="romav2_bidirectional_sampled")
+    parser.add_argument("--num-corresp", type=int, default=5000)
+    parser.add_argument("--seed", type=int, default=-1,
+                        help="Sampling seed; -1 uses non-deterministic sampling")
+    parser.add_argument("--out", default=None,
+                        help="Save sampled correspondence visualisation to this path")
+    parser.add_argument("--max-lines", type=int, default=512,
+                        help="Maximum correspondences to draw when --out is set")
+    args = parser.parse_args()
+
+    matches, confidence, precision_a, precision_b = infer_sampled(
+        args.img_a,
+        args.img_b,
+        url=args.url,
+        model_name=args.model,
+        num_corresp=args.num_corresp,
+        seed=args.seed,
+    )
+    print(f"sampled_matches:     shape={matches.shape}, min={matches.min():.4f}, max={matches.max():.4f}")
+    print(f"sampled_confidence:  shape={confidence.shape}, min={confidence.min():.4f}, max={confidence.max():.4f}")
+    print(f"sampled_precision_A: shape={precision_a.shape}, min={precision_a.min():.4f}, max={precision_a.max():.4f}")
+    print(f"sampled_precision_B: shape={precision_b.shape}, min={precision_b.min():.4f}, max={precision_b.max():.4f}")
+    if args.out:
+        visualise_sampled(
+            args.img_a,
+            args.img_b,
+            matches,
+            confidence,
+            args.out,
+            max_lines=args.max_lines,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_sampler_ops.py
+++ b/scripts/validate_sampler_ops.py
@@ -1,0 +1,55 @@
+"""Validate NumPy sampler primitives against the RoMaV2 PyTorch primitives."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLER_PATH = ROOT / "triton/model_repository/romav2_sampler/1/sampler.py"
+
+
+def load_sampler_module():
+    spec = importlib.util.spec_from_file_location("roma_sampler", SAMPLER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not import sampler from {SAMPLER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    sampler = load_sampler_module()
+    rng = np.random.default_rng(0)
+
+    values = rng.normal(size=(1, 12, 10, 4)).astype(np.float32)
+    grid = rng.uniform(-1.2, 1.2, size=(1, 12, 10, 2)).astype(np.float32)
+    np_sampled = sampler._grid_sample_bhwc(values, grid)
+    torch_sampled = F.grid_sample(
+        torch.from_numpy(values).permute(0, 3, 1, 2),
+        torch.from_numpy(grid),
+        mode="bilinear",
+        align_corners=False,
+    ).permute(0, 2, 3, 1).numpy()
+    np.testing.assert_allclose(np_sampled, torch_sampled, rtol=1e-5, atol=1e-5)
+
+    matches = rng.uniform(-1, 1, size=(64, 4)).astype(np.float32)
+    np_kde = sampler.kde(matches)
+    torch_matches = torch.from_numpy(matches)
+    torch_kde = (
+        (-(torch.cdist(torch_matches, torch_matches) ** 2) / (2 * 0.1**2))
+        .exp()
+        .sum(dim=-1)
+        .numpy()
+    )
+    np.testing.assert_allclose(np_kde, torch_kde, rtol=1e-4, atol=1e-4)
+    print("Sampler primitive validation passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/triton/model_repository/romav2_bidirectional_dense/config.pbtxt
+++ b/triton/model_repository/romav2_bidirectional_dense/config.pbtxt
@@ -1,0 +1,56 @@
+name: "romav2_bidirectional_dense"
+platform: "onnxruntime_onnx"
+max_batch_size: 0
+
+input [
+  {
+    name: "img_A"
+    data_type: TYPE_FP32
+    dims: [ -1, 3, 512, 512 ]
+  },
+  {
+    name: "img_B"
+    data_type: TYPE_FP32
+    dims: [ -1, 3, 512, 512 ]
+  }
+]
+
+output [
+  {
+    name: "warp_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "overlap_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "precision_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1, -1 ]
+  },
+  {
+    name: "warp_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "overlap_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "precision_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1, -1 ]
+  }
+]
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]

--- a/triton/model_repository/romav2_bidirectional_sampled/config.pbtxt
+++ b/triton/model_repository/romav2_bidirectional_sampled/config.pbtxt
@@ -1,0 +1,142 @@
+name: "romav2_bidirectional_sampled"
+platform: "ensemble"
+max_batch_size: 0
+
+input [
+  {
+    name: "img_A"
+    data_type: TYPE_FP32
+    dims: [ -1, 3, 512, 512 ]
+  },
+  {
+    name: "img_B"
+    data_type: TYPE_FP32
+    dims: [ -1, 3, 512, 512 ]
+  },
+  {
+    name: "num_corresp"
+    data_type: TYPE_INT64
+    dims: [ 1 ]
+  },
+  {
+    name: "seed"
+    data_type: TYPE_INT64
+    dims: [ 1 ]
+  }
+]
+
+output [
+  {
+    name: "sampled_matches"
+    data_type: TYPE_FP32
+    dims: [ -1, 4 ]
+  },
+  {
+    name: "sampled_confidence"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  },
+  {
+    name: "sampled_precision_A"
+    data_type: TYPE_FP32
+    dims: [ -1, 2, 2 ]
+  },
+  {
+    name: "sampled_precision_B"
+    data_type: TYPE_FP32
+    dims: [ -1, 2, 2 ]
+  }
+]
+
+ensemble_scheduling {
+  step [
+    {
+      model_name: "romav2_bidirectional_dense"
+      model_version: -1
+      input_map {
+        key: "img_A"
+        value: "img_A"
+      }
+      input_map {
+        key: "img_B"
+        value: "img_B"
+      }
+      output_map {
+        key: "warp_AB"
+        value: "dense_warp_AB"
+      }
+      output_map {
+        key: "overlap_AB"
+        value: "dense_overlap_AB"
+      }
+      output_map {
+        key: "precision_AB"
+        value: "dense_precision_AB"
+      }
+      output_map {
+        key: "warp_BA"
+        value: "dense_warp_BA"
+      }
+      output_map {
+        key: "overlap_BA"
+        value: "dense_overlap_BA"
+      }
+      output_map {
+        key: "precision_BA"
+        value: "dense_precision_BA"
+      }
+    },
+    {
+      model_name: "romav2_sampler"
+      model_version: -1
+      input_map {
+        key: "warp_AB"
+        value: "dense_warp_AB"
+      }
+      input_map {
+        key: "overlap_AB"
+        value: "dense_overlap_AB"
+      }
+      input_map {
+        key: "precision_AB"
+        value: "dense_precision_AB"
+      }
+      input_map {
+        key: "warp_BA"
+        value: "dense_warp_BA"
+      }
+      input_map {
+        key: "overlap_BA"
+        value: "dense_overlap_BA"
+      }
+      input_map {
+        key: "precision_BA"
+        value: "dense_precision_BA"
+      }
+      input_map {
+        key: "num_corresp"
+        value: "num_corresp"
+      }
+      input_map {
+        key: "seed"
+        value: "seed"
+      }
+      output_map {
+        key: "sampled_matches"
+        value: "sampled_matches"
+      }
+      output_map {
+        key: "sampled_confidence"
+        value: "sampled_confidence"
+      }
+      output_map {
+        key: "sampled_precision_A"
+        value: "sampled_precision_A"
+      }
+      output_map {
+        key: "sampled_precision_B"
+        value: "sampled_precision_B"
+      }
+    }
+  ]
+}

--- a/triton/model_repository/romav2_sampler/1/model.py
+++ b/triton/model_repository/romav2_sampler/1/model.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+from sampler import sample_roma_outputs
+
+
+class TritonPythonModel:
+    def initialize(self, args):
+        pass
+
+    def execute(self, requests):
+        responses = []
+        for request in requests:
+            warp_ab = pb_utils.get_input_tensor_by_name(request, "warp_AB").as_numpy()
+            overlap_ab = pb_utils.get_input_tensor_by_name(request, "overlap_AB").as_numpy()
+            precision_ab = pb_utils.get_input_tensor_by_name(request, "precision_AB").as_numpy()
+            warp_ba = pb_utils.get_input_tensor_by_name(request, "warp_BA").as_numpy()
+            overlap_ba = pb_utils.get_input_tensor_by_name(request, "overlap_BA").as_numpy()
+            precision_ba = pb_utils.get_input_tensor_by_name(request, "precision_BA").as_numpy()
+            num_corresp = int(pb_utils.get_input_tensor_by_name(request, "num_corresp").as_numpy().reshape(-1)[0])
+            seed = int(pb_utils.get_input_tensor_by_name(request, "seed").as_numpy().reshape(-1)[0])
+
+            matches, confidence, precision_a, precision_b = sample_roma_outputs(
+                warp_ab=warp_ab,
+                overlap_ab=overlap_ab,
+                precision_ab=precision_ab,
+                warp_ba=warp_ba,
+                overlap_ba=overlap_ba,
+                precision_ba=precision_ba,
+                num_corresp=num_corresp,
+                seed=seed,
+            )
+
+            responses.append(
+                pb_utils.InferenceResponse(
+                    output_tensors=[
+                        pb_utils.Tensor("sampled_matches", matches),
+                        pb_utils.Tensor("sampled_confidence", confidence),
+                        pb_utils.Tensor("sampled_precision_A", precision_a),
+                        pb_utils.Tensor("sampled_precision_B", precision_b),
+                    ]
+                )
+            )
+        return responses
+
+    def finalize(self):
+        pass

--- a/triton/model_repository/romav2_sampler/1/sampler.py
+++ b/triton/model_repository/romav2_sampler/1/sampler.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def normalized_grid(height: int, width: int) -> np.ndarray:
+    xs = np.linspace(-1.0 + 1.0 / width, 1.0 - 1.0 / width, width, dtype=np.float32)
+    ys = np.linspace(-1.0 + 1.0 / height, 1.0 - 1.0 / height, height, dtype=np.float32)
+    grid_x, grid_y = np.meshgrid(xs, ys, indexing="xy")
+    return np.stack((grid_x, grid_y), axis=-1)
+
+
+def _weighted_sample(
+    weights: np.ndarray,
+    count: int,
+    *,
+    replace: bool,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    weights = np.asarray(weights, dtype=np.float64).reshape(-1)
+    if count <= 0 or weights.size == 0:
+        return np.empty((0,), dtype=np.int64)
+    if not replace:
+        count = min(count, weights.size)
+    total = weights.sum()
+    if not np.isfinite(total) or total <= 0:
+        weights = np.ones_like(weights, dtype=np.float64)
+        total = weights.sum()
+    if not replace and np.count_nonzero(weights > 0) < count:
+        positive = np.flatnonzero(weights > 0)
+        zero = np.flatnonzero(weights <= 0)
+        positive_probs = weights[positive] / weights[positive].sum()
+        sampled_positive = rng.choice(
+            positive,
+            size=positive.size,
+            replace=False,
+            p=positive_probs,
+        )
+        sampled_zero = rng.choice(
+            zero,
+            size=count - positive.size,
+            replace=False,
+        )
+        return np.concatenate((sampled_positive, sampled_zero)).astype(np.int64)
+    probabilities = weights / total
+    return rng.choice(weights.size, size=count, replace=replace, p=probabilities).astype(np.int64)
+
+
+def _grid_sample_bhwc(values: np.ndarray, grid: np.ndarray) -> np.ndarray:
+    """Bilinear grid_sample for BHWC values with align_corners=False."""
+    batch, height, width, channels = values.shape
+    if batch != 1:
+        raise ValueError("RoMaV2 sample() only consumes the first batch item")
+
+    gx = grid[0, ..., 0]
+    gy = grid[0, ..., 1]
+    x = ((gx + 1.0) * width - 1.0) / 2.0
+    y = ((gy + 1.0) * height - 1.0) / 2.0
+
+    x0 = np.floor(x).astype(np.int64)
+    y0 = np.floor(y).astype(np.int64)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    wx = x - x0
+    wy = y - y0
+
+    def gather(ix: np.ndarray, iy: np.ndarray) -> np.ndarray:
+        valid = (ix >= 0) & (ix < width) & (iy >= 0) & (iy < height)
+        clipped_x = np.clip(ix, 0, width - 1)
+        clipped_y = np.clip(iy, 0, height - 1)
+        out = values[0, clipped_y, clipped_x]
+        return out * valid[..., None]
+
+    top_left = gather(x0, y0)
+    top_right = gather(x1, y0)
+    bottom_left = gather(x0, y1)
+    bottom_right = gather(x1, y1)
+
+    return (
+        top_left * ((1.0 - wx) * (1.0 - wy))[..., None]
+        + top_right * (wx * (1.0 - wy))[..., None]
+        + bottom_left * ((1.0 - wx) * wy)[..., None]
+        + bottom_right * (wx * wy)[..., None]
+    )[None].astype(values.dtype, copy=False)
+
+
+def kde(matches: np.ndarray, std: float = 0.1) -> np.ndarray:
+    matches = matches.astype(np.float32, copy=False)
+    diff = matches[:, None, :] - matches[None, :, :]
+    sq_dist = np.sum(diff * diff, axis=-1)
+    return np.exp(-sq_dist / (2.0 * std * std)).sum(axis=-1).astype(np.float32)
+
+
+def sample_roma_outputs(
+    *,
+    warp_ab: np.ndarray,
+    overlap_ab: np.ndarray,
+    precision_ab: np.ndarray,
+    warp_ba: np.ndarray | None,
+    overlap_ba: np.ndarray | None,
+    precision_ba: np.ndarray | None,
+    num_corresp: int,
+    seed: int = -1,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Sample dense RoMaV2 outputs with the same data flow as RoMaV2.sample().
+
+    The original implementation samples only the first batch item; this function
+    intentionally preserves that behavior.
+    """
+    if num_corresp < 0:
+        raise ValueError("num_corresp must be non-negative")
+
+    rng = np.random.default_rng(None if seed < 0 else seed)
+
+    warp_ab = warp_ab[0].astype(np.float32, copy=False)
+    overlap_ab = overlap_ab[0].reshape(-1).astype(np.float32, copy=False)
+    precision_ab = precision_ab[0].astype(np.float32, copy=False)
+
+    height, width, _ = warp_ab.shape
+    grid = normalized_grid(height, width)
+    matches_ab = np.concatenate((grid, warp_ab), axis=-1).reshape(-1, 4)
+
+    has_ba = warp_ba is not None and overlap_ba is not None and precision_ba is not None
+    if has_ba:
+        warp_ba_0 = warp_ba[0].astype(np.float32, copy=False)
+        overlap_ba_0 = overlap_ba[0].reshape(-1).astype(np.float32, copy=False)
+        precision_ba_0 = precision_ba[0].astype(np.float32, copy=False)
+
+        precision_a = _grid_sample_bhwc(
+            precision_ba_0.reshape(1, height, width, -1),
+            warp_ab[None],
+        ).reshape(height, width, 2, 2)
+        precision_b = _grid_sample_bhwc(
+            precision_ab.reshape(1, height, width, -1),
+            warp_ba_0[None],
+        ).reshape(height, width, 2, 2)
+        precision_fwd = np.stack((precision_a, precision_ab), axis=-3).reshape(-1, 2, 2, 2)
+        precision_bwd = np.stack((precision_ba_0, precision_b), axis=-3).reshape(-1, 2, 2, 2)
+        precision = np.concatenate((precision_fwd, precision_bwd), axis=0)
+
+        matches_ba = np.concatenate((warp_ba_0, grid), axis=-1).reshape(-1, 4)
+        confidence = np.concatenate((overlap_ab, overlap_ba_0), axis=0)
+        matches = np.concatenate((matches_ab, matches_ba), axis=0)
+    else:
+        precision = precision_ab.reshape(-1, 2, 2)[:, None]
+        confidence = overlap_ab
+        matches = matches_ab
+
+    in_frame = (np.max(np.abs(matches), axis=-1) <= (1.0 - 1.0 / height)).astype(np.float32)
+    confidence = confidence * in_frame
+
+    expansion_factor = 4
+    first_count = min(expansion_factor * num_corresp, confidence.shape[0])
+    corresp_inds = _weighted_sample(confidence, first_count, replace=False, rng=rng)
+
+    sampled_matches = matches[corresp_inds]
+    sampled_confidence = confidence[corresp_inds]
+    sampled_precision = precision[corresp_inds]
+
+    density = kde(sampled_matches)
+    probabilities = 1.0 / (density + 1.0)
+    probabilities[density < 10.0] = 1e-7
+
+    final_count = min(num_corresp, sampled_confidence.shape[0])
+    balanced = _weighted_sample(probabilities, final_count, replace=False, rng=rng)
+
+    final_precision = sampled_precision[balanced]
+    return (
+        sampled_matches[balanced].astype(np.float32, copy=False),
+        sampled_confidence[balanced].astype(np.float32, copy=False),
+        final_precision[:, 0].astype(np.float32, copy=False),
+        final_precision[:, 1].astype(np.float32, copy=False),
+    )

--- a/triton/model_repository/romav2_sampler/config.pbtxt
+++ b/triton/model_repository/romav2_sampler/config.pbtxt
@@ -1,0 +1,76 @@
+name: "romav2_sampler"
+backend: "python"
+max_batch_size: 0
+
+input [
+  {
+    name: "warp_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "overlap_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "precision_AB"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1, -1 ]
+  },
+  {
+    name: "warp_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "overlap_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1 ]
+  },
+  {
+    name: "precision_BA"
+    data_type: TYPE_FP32
+    dims: [ -1, -1, -1, -1, -1 ]
+  },
+  {
+    name: "num_corresp"
+    data_type: TYPE_INT64
+    dims: [ 1 ]
+  },
+  {
+    name: "seed"
+    data_type: TYPE_INT64
+    dims: [ 1 ]
+  }
+]
+
+output [
+  {
+    name: "sampled_matches"
+    data_type: TYPE_FP32
+    dims: [ -1, 4 ]
+  },
+  {
+    name: "sampled_confidence"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  },
+  {
+    name: "sampled_precision_A"
+    data_type: TYPE_FP32
+    dims: [ -1, 2, 2 ]
+  },
+  {
+    name: "sampled_precision_B"
+    data_type: TYPE_FP32
+    dims: [ -1, 2, 2 ]
+  }
+]
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]


### PR DESCRIPTION
## Summary
- add precision-export support for RoMaV2 ONNX so sampling can preserve the original sample() precision outputs
- add a Triton ensemble that chains a bidirectional dense ONNX model into a Python sampler model and returns sparse matches/confidence/precision only
- add a sampled Triton client, sampler primitive validation, and README deployment notes

## Validation
- python3 -m py_compile scripts/export_onnx.py scripts/triton_sampled_client.py scripts/validate_sampler_ops.py triton/model_repository/romav2_sampler/1/sampler.py triton/model_repository/romav2_sampler/1/model.py
- python3 scripts/validate_sampler_ops.py
- remote export on crazypenguins: python3 scripts/export_onnx.py --output triton/model_repository/romav2_bidirectional_dense/1/model.onnx --setting fast --bidirectional --include-precision
- remote direct ONNX + sampler on Toronto sample images returned 512 sampled matches/confidence/precision tensors
- remote temporary Triton deployment loaded romav2_bidirectional_dense + romav2_sampler + romav2_bidirectional_sampled and scripts/triton_sampled_client.py returned sampled outputs