### PR TITLE
Run Triton sampler through Torch DLPack on GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,24 @@ cp romav2_fast_bidir_precision.onnx \
 
 Then call the user-facing ensemble model `romav2_bidirectional_sampled`, not the dense model. The dense tensors stay inside Triton.
 
+For the fast sampled ensemble path, the Triton Python sampler uses PyTorch via DLPack and should run as a GPU Python backend instance. The plain Triton `py3` images do not always include PyTorch, so build a torch-enabled Triton image before deploying this model:
+
+```bash
+docker build \
+  -f triton/Dockerfile.torch-sampler \
+  -t romav2-triton-torch-sampler:25.07-py3 \
+  triton
+```
+
+On Kubernetes, request a GPU and use the NVIDIA runtime class if your cluster requires it:
+
+```yaml
+runtimeClassName: nvidia
+resources:
+  limits:
+    nvidia.com/gpu: 1
+```
+
 If you export `turbo` or `base`, update the `img_A`/`img_B` input dimensions in the relevant `config.pbtxt` to `320×320` or `640×640`.
 
 The checked-in Triton configs keep output dimensions fully dynamic for compatibility with `nvcr.io/nvidia/tritonserver:23.12-py3`. If a newer Triton version reports that the model expects concrete output dimensions, set warp outputs to `[ -1, -1, -1, 2 ]`, overlap outputs to `[ -1, -1, -1, 1 ]`, and precision outputs to `[ -1, -1, -1, 2, 2 ]` in that environment.
@@ -205,7 +223,7 @@ docker run --rm -d \
   tritonserver --model-repository=/models
 ```
 
-Add `--gpus all` if you have a CUDA GPU. Wait ~10 seconds, then verify:
+Add `--gpus all` if you have a CUDA GPU. For `romav2_bidirectional_sampled`, use the torch-enabled image above so the Python sampler can stay on GPU. Wait ~10 seconds, then verify:
 
 ```bash
 curl http://localhost:8000/v2/health/ready        # → HTTP 200
@@ -282,7 +300,7 @@ romav2-onnx/
 │       │   ├── config.pbtxt  # Internal dense ONNX model for the sampled ensemble
 │       │   └── 1/            # Place precision-exported bidirectional model.onnx here
 │       ├── romav2_sampler/
-│       │   ├── config.pbtxt  # Triton Python backend sampler
+│       │   ├── config.pbtxt  # Triton Python backend sampler, GPU torch/DLPack path
 │       │   └── 1/
 │       └── romav2_bidirectional_sampled/
 │           ├── config.pbtxt  # User-facing ensemble returning sparse samples
@@ -301,4 +319,4 @@ romav2-onnx/
 - **Float32 only** — all AMP/bfloat16 paths are disabled at export time; the full graph runs in float32 for ORT compatibility.
 - **Static H/W** — height and width are baked into the ONNX graph per setting. Export a separate `.onnx` per setting if you need multiple resolutions.
 - **Batch dimension** — the Triton config uses `max_batch_size: 0` with an explicit batch dim in `dims`, matching the ONNX model's fully-dynamic shape annotation. Pass batches of size ≥ 1 from your client.
-- **GPU** — the exported model runs on CPU by default in both ORT and Triton. For CUDA GPU inference in Triton, set `kind: KIND_GPU` in `config.pbtxt` and pass `--gpus all` to Docker.
+- **GPU** — dense ONNX inference can run on CUDA with `KIND_GPU`. The sampled ensemble also needs a torch-enabled Triton image so `romav2_sampler` can consume DLPack tensors and run sampling on CUDA instead of copying dense tensors back to CPU.

--- a/scripts/benchmark_triton_sampled.py
+++ b/scripts/benchmark_triton_sampled.py
@@ -1,0 +1,171 @@
+"""Benchmark the sampled RoMaV2 Triton ensemble under repeated load."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import statistics
+import time
+from dataclasses import dataclass
+
+import numpy as np
+from PIL import Image
+
+
+MODEL_H = MODEL_W = 512
+OUTPUT_NAMES = [
+    "sampled_matches",
+    "sampled_confidence",
+    "sampled_precision_A",
+    "sampled_precision_B",
+]
+
+
+@dataclass(frozen=True)
+class RequestData:
+    img_a: np.ndarray
+    img_b: np.ndarray
+    num_corresp: np.ndarray
+    seed: np.ndarray
+
+
+def load_image(path: str) -> np.ndarray:
+    img = Image.open(path).convert("RGB").resize((MODEL_W, MODEL_H), Image.LANCZOS)
+    arr = np.asarray(img, dtype=np.float32) / 255.0
+    return arr.transpose(2, 0, 1)[None]
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, round((pct / 100.0) * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+def make_http_client(url: str, model_name: str, timeout: float):
+    import tritonclient.http as httpclient
+
+    client = httpclient.InferenceServerClient(url=url, concurrency=1)
+
+    def infer(data: RequestData):
+        inputs = [
+            httpclient.InferInput("img_A", data.img_a.shape, "FP32"),
+            httpclient.InferInput("img_B", data.img_b.shape, "FP32"),
+            httpclient.InferInput("num_corresp", data.num_corresp.shape, "INT64"),
+            httpclient.InferInput("seed", data.seed.shape, "INT64"),
+        ]
+        inputs[0].set_data_from_numpy(data.img_a)
+        inputs[1].set_data_from_numpy(data.img_b)
+        inputs[2].set_data_from_numpy(data.num_corresp)
+        inputs[3].set_data_from_numpy(data.seed)
+        outputs = [httpclient.InferRequestedOutput(name) for name in OUTPUT_NAMES]
+        return client.infer(
+            model_name,
+            inputs=inputs,
+            outputs=outputs,
+            request_id="benchmark",
+        )
+
+    return infer
+
+
+def make_grpc_client(url: str, model_name: str, timeout: float):
+    import tritonclient.grpc as grpcclient
+
+    client = grpcclient.InferenceServerClient(url=url)
+
+    def infer(data: RequestData):
+        inputs = [
+            grpcclient.InferInput("img_A", data.img_a.shape, "FP32"),
+            grpcclient.InferInput("img_B", data.img_b.shape, "FP32"),
+            grpcclient.InferInput("num_corresp", data.num_corresp.shape, "INT64"),
+            grpcclient.InferInput("seed", data.seed.shape, "INT64"),
+        ]
+        inputs[0].set_data_from_numpy(data.img_a)
+        inputs[1].set_data_from_numpy(data.img_b)
+        inputs[2].set_data_from_numpy(data.num_corresp)
+        inputs[3].set_data_from_numpy(data.seed)
+        outputs = [grpcclient.InferRequestedOutput(name) for name in OUTPUT_NAMES]
+        return client.infer(
+            model_name=model_name,
+            inputs=inputs,
+            outputs=outputs,
+            client_timeout=timeout,
+        )
+
+    return infer
+
+
+def run_one(infer, data: RequestData) -> float:
+    start = time.perf_counter()
+    infer(data)
+    return time.perf_counter() - start
+
+
+def summarize(name: str, latencies: list[float], wall_time: float):
+    qps = len(latencies) / wall_time if wall_time > 0 else float("nan")
+    print(f"\n{name}")
+    print(f"  requests: {len(latencies)}")
+    print(f"  wall:     {wall_time:.3f}s")
+    print(f"  qps:      {qps:.3f}")
+    print(f"  mean:     {statistics.mean(latencies):.3f}s")
+    print(f"  p50:      {percentile(latencies, 50):.3f}s")
+    print(f"  p95:      {percentile(latencies, 95):.3f}s")
+    print(f"  p99:      {percentile(latencies, 99):.3f}s")
+    print(f"  min/max:  {min(latencies):.3f}s / {max(latencies):.3f}s")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark sampled RoMaV2 Triton ensemble")
+    parser.add_argument("img_a")
+    parser.add_argument("img_b")
+    parser.add_argument("--url", default="localhost:8000")
+    parser.add_argument("--model", default="romav2_bidirectional_sampled")
+    parser.add_argument("--protocol", choices=["http", "grpc"], default="http")
+    parser.add_argument("--num-corresp", type=int, default=512)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--requests", type=int, default=32)
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    args = parser.parse_args()
+
+    control_shape = (1, 1) if args.model.endswith("_batch") else (1,)
+    data = RequestData(
+        img_a=load_image(args.img_a),
+        img_b=load_image(args.img_b),
+        num_corresp=np.full(control_shape, args.num_corresp, dtype=np.int64),
+        seed=np.full(control_shape, args.seed, dtype=np.int64),
+    )
+    make_client = make_http_client if args.protocol == "http" else make_grpc_client
+
+    def make_infer():
+        return make_client(args.url, args.model, args.timeout)
+
+    print(
+        f"protocol={args.protocol} url={args.url} model={args.model} requests={args.requests} "
+        f"concurrency={args.concurrency} num_corresp={args.num_corresp}"
+    )
+
+    warmup_infer = make_infer()
+    for _ in range(args.warmup):
+        warmup_infer(data)
+
+    start = time.perf_counter()
+    if args.concurrency == 1:
+        infer = make_infer()
+        latencies = [run_one(infer, data) for _ in range(args.requests)]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [
+                pool.submit(run_one, make_infer(), data)
+                for _ in range(args.requests)
+            ]
+            latencies = [future.result() for future in concurrent.futures.as_completed(futures)]
+    wall_time = time.perf_counter() - start
+    summarize("sampled ensemble", latencies, wall_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_sampler_ops.py
+++ b/scripts/validate_sampler_ops.py
@@ -1,4 +1,4 @@
-"""Validate NumPy sampler primitives against the RoMaV2 PyTorch primitives."""
+"""Validate sampler primitives against the RoMaV2 PyTorch primitives."""
 
 from __future__ import annotations
 
@@ -48,6 +48,36 @@ def main():
         .numpy()
     )
     np.testing.assert_allclose(np_kde, torch_kde, rtol=1e-4, atol=1e-4)
+
+    batch, height, width = 1, 16, 16
+    warp_ab = rng.uniform(-1, 1, size=(batch, height, width, 2)).astype(np.float32)
+    overlap_ab = rng.uniform(0, 1, size=(batch, height, width, 1)).astype(np.float32)
+    precision_ab = np.broadcast_to(
+        np.eye(2, dtype=np.float32),
+        (batch, height, width, 2, 2),
+    ).copy()
+    warp_ba = rng.uniform(-1, 1, size=(batch, height, width, 2)).astype(np.float32)
+    overlap_ba = rng.uniform(0, 1, size=(batch, height, width, 1)).astype(np.float32)
+    precision_ba = np.broadcast_to(
+        np.eye(2, dtype=np.float32),
+        (batch, height, width, 2, 2),
+    ).copy()
+    torch_out = sampler.sample_roma_outputs_torch(
+        warp_ab=torch.from_numpy(warp_ab),
+        overlap_ab=torch.from_numpy(overlap_ab),
+        precision_ab=torch.from_numpy(precision_ab),
+        warp_ba=torch.from_numpy(warp_ba),
+        overlap_ba=torch.from_numpy(overlap_ba),
+        precision_ba=torch.from_numpy(precision_ba),
+        num_corresp=32,
+        seed=7,
+    )
+    assert [tuple(value.shape) for value in torch_out] == [
+        (32, 4),
+        (32,),
+        (32, 2, 2),
+        (32, 2, 2),
+    ]
     print("Sampler primitive validation passed.")
 
 

--- a/triton/Dockerfile.torch-sampler
+++ b/triton/Dockerfile.torch-sampler
@@ -1,0 +1,7 @@
+ARG TRITON_IMAGE=nvcr.io/nvidia/tritonserver:25.07-py3
+FROM ${TRITON_IMAGE}
+
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir torch --index-url ${TORCH_INDEX_URL}

--- a/triton/model_repository/romav2_sampler/1/model.py
+++ b/triton/model_repository/romav2_sampler/1/model.py
@@ -3,44 +3,99 @@ from __future__ import annotations
 import numpy as np
 import triton_python_backend_utils as pb_utils
 
-from sampler import sample_roma_outputs
+from sampler import sample_roma_outputs, sample_roma_outputs_torch
+
+try:
+    import torch
+    from torch.utils.dlpack import from_dlpack, to_dlpack
+except ImportError:  # Plain Triton py3 images do not ship PyTorch.
+    torch = None
+    from_dlpack = None
+    to_dlpack = None
+
+
+def _input_as_torch(request, name: str) -> torch.Tensor:
+    if from_dlpack is None:
+        raise RuntimeError("PyTorch/DLPack path is unavailable")
+    tensor = pb_utils.get_input_tensor_by_name(request, name)
+    return from_dlpack(tensor.to_dlpack())
+
+
+def _output_from_torch(name: str, tensor: torch.Tensor):
+    if to_dlpack is None:
+        raise RuntimeError("PyTorch/DLPack path is unavailable")
+    return pb_utils.Tensor.from_dlpack(name, to_dlpack(tensor.contiguous()))
+
+
+def _execute_torch(request, num_corresp: int, seed: int):
+    matches, confidence, precision_a, precision_b = sample_roma_outputs_torch(
+        warp_ab=_input_as_torch(request, "warp_AB"),
+        overlap_ab=_input_as_torch(request, "overlap_AB"),
+        precision_ab=_input_as_torch(request, "precision_AB"),
+        warp_ba=_input_as_torch(request, "warp_BA"),
+        overlap_ba=_input_as_torch(request, "overlap_BA"),
+        precision_ba=_input_as_torch(request, "precision_BA"),
+        num_corresp=num_corresp,
+        seed=seed,
+    )
+    return [
+        _output_from_torch("sampled_matches", matches),
+        _output_from_torch("sampled_confidence", confidence),
+        _output_from_torch("sampled_precision_A", precision_a),
+        _output_from_torch("sampled_precision_B", precision_b),
+    ]
+
+
+def _execute_numpy(request, num_corresp: int, seed: int):
+    warp_ab = pb_utils.get_input_tensor_by_name(request, "warp_AB").as_numpy()
+    overlap_ab = pb_utils.get_input_tensor_by_name(request, "overlap_AB").as_numpy()
+    precision_ab = pb_utils.get_input_tensor_by_name(request, "precision_AB").as_numpy()
+    warp_ba = pb_utils.get_input_tensor_by_name(request, "warp_BA").as_numpy()
+    overlap_ba = pb_utils.get_input_tensor_by_name(request, "overlap_BA").as_numpy()
+    precision_ba = pb_utils.get_input_tensor_by_name(request, "precision_BA").as_numpy()
+
+    matches, confidence, precision_a, precision_b = sample_roma_outputs(
+        warp_ab=warp_ab,
+        overlap_ab=overlap_ab,
+        precision_ab=precision_ab,
+        warp_ba=warp_ba,
+        overlap_ba=overlap_ba,
+        precision_ba=precision_ba,
+        num_corresp=num_corresp,
+        seed=seed,
+    )
+    return [
+        pb_utils.Tensor("sampled_matches", matches),
+        pb_utils.Tensor("sampled_confidence", confidence),
+        pb_utils.Tensor("sampled_precision_A", precision_a),
+        pb_utils.Tensor("sampled_precision_B", precision_b),
+    ]
 
 
 class TritonPythonModel:
     def initialize(self, args):
-        pass
+        self._warned_numpy_fallback = False
 
     def execute(self, requests):
         responses = []
         for request in requests:
-            warp_ab = pb_utils.get_input_tensor_by_name(request, "warp_AB").as_numpy()
-            overlap_ab = pb_utils.get_input_tensor_by_name(request, "overlap_AB").as_numpy()
-            precision_ab = pb_utils.get_input_tensor_by_name(request, "precision_AB").as_numpy()
-            warp_ba = pb_utils.get_input_tensor_by_name(request, "warp_BA").as_numpy()
-            overlap_ba = pb_utils.get_input_tensor_by_name(request, "overlap_BA").as_numpy()
-            precision_ba = pb_utils.get_input_tensor_by_name(request, "precision_BA").as_numpy()
             num_corresp = int(pb_utils.get_input_tensor_by_name(request, "num_corresp").as_numpy().reshape(-1)[0])
             seed = int(pb_utils.get_input_tensor_by_name(request, "seed").as_numpy().reshape(-1)[0])
 
-            matches, confidence, precision_a, precision_b = sample_roma_outputs(
-                warp_ab=warp_ab,
-                overlap_ab=overlap_ab,
-                precision_ab=precision_ab,
-                warp_ba=warp_ba,
-                overlap_ba=overlap_ba,
-                precision_ba=precision_ba,
-                num_corresp=num_corresp,
-                seed=seed,
-            )
-
+            try:
+                output_tensors = _execute_torch(request, num_corresp, seed)
+            except Exception as exc:
+                if not self._warned_numpy_fallback:
+                    print(
+                        "RoMaV2 sampler falling back to NumPy CPU path: "
+                        f"{type(exc).__name__}: {exc}",
+                        flush=True,
+                    )
+                    self._warned_numpy_fallback = True
+                output_tensors = _execute_numpy(request, num_corresp, seed)
             responses.append(
                 pb_utils.InferenceResponse(
-                    output_tensors=[
-                        pb_utils.Tensor("sampled_matches", matches),
-                        pb_utils.Tensor("sampled_confidence", confidence),
-                        pb_utils.Tensor("sampled_precision_A", precision_a),
-                        pb_utils.Tensor("sampled_precision_B", precision_b),
-                    ]
+                    output_tensors=output_tensors
                 )
             )
         return responses

--- a/triton/model_repository/romav2_sampler/1/sampler.py
+++ b/triton/model_repository/romav2_sampler/1/sampler.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError:  # pragma: no cover - Triton image is expected to include torch.
+    torch = None
+    F = None
+
 
 def normalized_grid(height: int, width: int) -> np.ndarray:
     xs = np.linspace(-1.0 + 1.0 / width, 1.0 - 1.0 / width, width, dtype=np.float32)
@@ -90,6 +97,166 @@ def kde(matches: np.ndarray, std: float = 0.1) -> np.ndarray:
     diff = matches[:, None, :] - matches[None, :, :]
     sq_dist = np.sum(diff * diff, axis=-1)
     return np.exp(-sq_dist / (2.0 * std * std)).sum(axis=-1).astype(np.float32)
+
+
+def normalized_grid_torch(height: int, width: int, *, device: torch.device) -> torch.Tensor:
+    xs = torch.linspace(
+        -1.0 + 1.0 / width,
+        1.0 - 1.0 / width,
+        width,
+        dtype=torch.float32,
+        device=device,
+    )
+    ys = torch.linspace(
+        -1.0 + 1.0 / height,
+        1.0 - 1.0 / height,
+        height,
+        dtype=torch.float32,
+        device=device,
+    )
+    grid_y, grid_x = torch.meshgrid(ys, xs, indexing="ij")
+    return torch.stack((grid_x, grid_y), dim=-1)
+
+
+def bhwc_grid_sample_torch(
+    values: torch.Tensor,
+    grid: torch.Tensor,
+    *,
+    mode: str = "bilinear",
+    align_corners: bool | None = False,
+) -> torch.Tensor:
+    return F.grid_sample(
+        values.permute(0, 3, 1, 2),
+        grid,
+        mode=mode,
+        align_corners=align_corners,
+    ).permute(0, 2, 3, 1)
+
+
+def kde_torch(matches: torch.Tensor, std: float = 0.1) -> torch.Tensor:
+    return (-(torch.cdist(matches, matches) ** 2) / (2 * std**2)).exp().sum(dim=-1)
+
+
+def _torch_multinomial(
+    weights: torch.Tensor,
+    count: int,
+    *,
+    replacement: bool,
+    generator: torch.Generator | None,
+) -> torch.Tensor:
+    if count <= 0 or weights.numel() == 0:
+        return torch.empty((0,), dtype=torch.long, device=weights.device)
+    if not replacement:
+        count = min(count, weights.numel())
+    return torch.multinomial(weights, count, replacement=replacement, generator=generator)
+
+
+def sample_roma_outputs_torch(
+    *,
+    warp_ab: torch.Tensor,
+    overlap_ab: torch.Tensor,
+    precision_ab: torch.Tensor,
+    warp_ba: torch.Tensor | None,
+    overlap_ba: torch.Tensor | None,
+    precision_ba: torch.Tensor | None,
+    num_corresp: int,
+    seed: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Torch implementation of RoMaV2.sample() for Triton Python backend.
+
+    This keeps the dense tensors on CUDA when Triton passes GPU buffers through
+    DLPack. It intentionally mirrors the original RoMaV2.sample() data flow.
+    """
+    if torch is None or F is None:
+        raise RuntimeError("PyTorch is required for sample_roma_outputs_torch")
+    if num_corresp < 0:
+        raise ValueError("num_corresp must be non-negative")
+    generator = None
+    if seed >= 0:
+        generator = torch.Generator(device=warp_ab.device)
+        generator.manual_seed(seed)
+
+    warp = warp_ab[0].float()
+    confidence_ab = overlap_ab[0].reshape(-1).float()
+    precision_ab_0 = precision_ab[0].float()
+
+    height, width, _ = warp.shape
+    grid = normalized_grid_torch(height, width, device=warp.device)
+    matches_ab = torch.cat((grid, warp), dim=-1).reshape(-1, 4)
+
+    has_ba = warp_ba is not None and overlap_ba is not None and precision_ba is not None
+    if has_ba:
+        warp_ba_0 = warp_ba[0].float()
+        confidence_ba = overlap_ba[0].reshape(-1).float()
+        precision_ba_0 = precision_ba[0].float()
+
+        precision_a = bhwc_grid_sample_torch(
+            precision_ba_0[None].reshape(1, height, width, -1),
+            warp[None],
+            mode="bilinear",
+            align_corners=False,
+        ).reshape(height, width, 2, 2)
+        precision_b = bhwc_grid_sample_torch(
+            precision_ab_0[None].reshape(1, height, width, -1),
+            warp_ba_0[None],
+            mode="bilinear",
+            align_corners=False,
+        ).reshape(height, width, 2, 2)
+        precision_fwd = torch.stack((precision_a, precision_ab_0), dim=-3).reshape(
+            -1, 2, 2, 2
+        )
+        precision_bwd = torch.stack((precision_ba_0, precision_b), dim=-3).reshape(
+            -1, 2, 2, 2
+        )
+        precision = torch.cat((precision_fwd, precision_bwd), dim=0)
+
+        matches_ba = torch.cat((warp_ba_0, grid), dim=-1).reshape(-1, 4)
+        confidence = torch.cat((confidence_ab, confidence_ba), dim=0)
+        matches = torch.cat((matches_ab, matches_ba), dim=0)
+    else:
+        precision = precision_ab_0.reshape(-1, 2, 2)
+        confidence = confidence_ab.reshape(-1)
+        matches = matches_ab
+
+    confidence = confidence * matches.abs().amax(dim=-1).le(1 - 1 / height).float()
+
+    expansion_factor = 4
+    first_count = min(expansion_factor * num_corresp, confidence.numel())
+    corresp_inds = _torch_multinomial(
+        confidence,
+        first_count,
+        replacement=False,
+        generator=generator,
+    )
+
+    sampled_matches = matches[corresp_inds]
+    sampled_confidence = confidence[corresp_inds]
+    sampled_precision = precision[corresp_inds]
+
+    density = kde_torch(sampled_matches)
+    p = 1 / (density + 1)
+    p[density < 10] = 1e-7
+    final_count = min(num_corresp, sampled_confidence.numel())
+    balanced = _torch_multinomial(
+        p,
+        final_count,
+        replacement=False,
+        generator=generator,
+    )
+
+    final_precision = sampled_precision[balanced]
+    if has_ba:
+        precision_a_out = final_precision[:, 0]
+        precision_b_out = final_precision[:, 1]
+    else:
+        precision_a_out = final_precision[:, 0]
+        precision_b_out = final_precision[:, 1]
+    return (
+        sampled_matches[balanced].contiguous(),
+        sampled_confidence[balanced].contiguous(),
+        precision_a_out.contiguous(),
+        precision_b_out.contiguous(),
+    )
 
 
 def sample_roma_outputs(

--- a/triton/model_repository/romav2_sampler/config.pbtxt
+++ b/triton/model_repository/romav2_sampler/config.pbtxt
@@ -71,6 +71,6 @@ output [
 instance_group [
   {
     count: 1
-    kind: KIND_CPU
+    kind: KIND_GPU
   }
 ]


### PR DESCRIPTION
## Summary
- add a Torch/DLPack implementation of the RoMaV2 sampled backend so dense tensors can stay on GPU inside Triton
- make the sampler backend a GPU instance and keep a NumPy fallback path for non-torch environments
- add a Triton Dockerfile for a torch-enabled sampler image and document the Kubernetes GPU runtime requirements
- extend sampler validation to exercise the Torch sampling path

## Validation
- python3 -m py_compile triton/model_repository/romav2_sampler/1/sampler.py triton/model_repository/romav2_sampler/1/model.py scripts/validate_sampler_ops.py
- python3 scripts/validate_sampler_ops.py
- remote Triton GPU test on crazypenguins with torch-enabled tritonserver: dense model and sampler both loaded on GPU device 0
- benchmark: Triton HTTP ensemble with dense GPU + torch GPU sampler, num_corresp=512, mean 0.770s over 5 runs; previous dense GPU + NumPy CPU sampler was 0.906s